### PR TITLE
Always render frozen columns and filter rendering for non-frozen columns

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2295,7 +2295,7 @@ if (typeof Slick === "undefined") {
             appendCellHtml(stringArrayL, row, i, colspan, d);
           }
         } else if (hasFrozenColumns() && ( i <= options.frozenColumn )) {
-          appendCellHtml(stringArrayL, row, i, colspan);
+          appendCellHtml(stringArrayL, row, i, colspan, d);
         }
 
         if (colspan > 1) {
@@ -2742,12 +2742,6 @@ if (typeof Slick === "undefined") {
       range.top = Math.max(0, range.top);
       range.bottom = Math.min(getDataLengthIncludingAddNew() - 1, range.bottom);
 
-      range.leftPx -= viewportW;
-      range.rightPx += viewportW;
-
-      range.leftPx = Math.max(0, range.leftPx);
-      range.rightPx = Math.min(canvasWidth, range.rightPx);
-
       return range;
     }
 
@@ -3022,9 +3016,15 @@ if (typeof Slick === "undefined") {
 
       // Render frozen bottom rows
       if (options.frozenBottom) {
-        renderRows({
+        var frozenRowsRendered = {
           top: actualFrozenRow, bottom: getDataLength() - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
-        });
+        };
+
+        if (lastRenderedScrollLeft != scrollLeft) {
+          cleanUpAndRenderCells(frozenRowsRendered);
+        }
+
+        renderRows(frozenRowsRendered);
       }
 
       postProcessFromRow = visible.top;


### PR DESCRIPTION
There was a bug which caused frozen columns cell content to disappear when the non-frozen viewport was too wide and scrolled to the right, content then disappears when scrolling up and down in the grid.

Inside the getRenderedRange function it would calculate incorrect viewport dimensions and filter out frozen columns that were visible. I've updated that bit so it'll render a viewport for what's in the right non-frozen part of the grid and then everything that's frozen for the left viewport.
