### PR TITLE
Fix some bugs / add enhancement

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2353,7 +2353,18 @@ if (typeof Slick === "undefined") {
       // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
       if (item) {
         var value = getDataItemValueForColumn(item, m);
-        stringArray.push(getFormatter(row, m)(row, cell, value, m, item));
+        
+        // pass metadata to formatter
+        var metadata = data.getItemMetadata && data.getItemMetadata(row);
+        metadata = metadata && metadata.columns;
+        
+        if( metadata ) {
+        	var columnData = metadata[m.id] || metadata[cell];
+        	stringArray.push(getFormatter(row, m)(row, cell, value, m, item, columnData ));
+        }        
+        else {
+        	stringArray.push(getFormatter(row, m)(row, cell, value, m, item));
+        }
       }
 
       stringArray.push("</div>");

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1200,6 +1200,7 @@ if (typeof Slick === "undefined") {
       var positionValid = limit.start <= currentPosition && currentPosition <= limit.end;
 
       return {
+    	limit: limit,
         valid: positionValid,
         message: positionValid? '': 'Column "'.concat($item.text(), '" can be reordered only within the "', limit.group.name, '" group!')
       };
@@ -1252,10 +1253,12 @@ if (typeof Slick === "undefined") {
           var cancel = false;
           clearInterval(columnScrollTimer);
           columnScrollTimer = null;
+          var limit = null;
 
           if (treeColumns.hasDepth()) {
             var validPositionInGroup = columnPositionValidInGroup(ui.item);
-
+            limit = validPositionInGroup.limit;
+            
             cancel = !validPositionInGroup.valid;
 
             if (cancel)
@@ -1276,13 +1279,30 @@ if (typeof Slick === "undefined") {
           }
           setColumns(reorderedColumns);
 
-          trigger(self.onColumnsReordered, {});
+          trigger(self.onColumnsReordered, { impactedColumns : getImpactedColumns( limit ) });
           e.stopPropagation();
           setupColumnResize();
         }
       });
     }
 
+	function getImpactedColumns( limit ) {
+    	var impactedColumns = [];
+    	
+    	if( limit != undefined ) {
+    		   		
+	   		for( var i = limit.start; i <= limit.end; i++ ) {
+	   			impactedColumns.push( columns[i] );
+	   		}
+    	}
+    	else {
+    		
+    		impactedColumns = columns;
+    	}
+   		   		
+   		return impactedColumns;
+    }    
+    
     function setupColumnResize() {
       var $col, j, k, c, pageX, columnElements, minPageX, maxPageX, firstResizable, lastResizable;
       columnElements = $headers.children();

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2237,6 +2237,25 @@ if (typeof Slick === "undefined") {
           options.defaultFormatter;
     }
 
+    function callFormatter( row, cell, value, m, item ) {
+    	
+    	var result;
+    	
+        // pass metadata to formatter
+        var metadata = data.getItemMetadata && data.getItemMetadata(row);
+        metadata = metadata && metadata.columns;
+        
+        if( metadata ) {
+        	var columnData = metadata[m.id] || metadata[cell];
+        	result = getFormatter(row, m)(row, cell, value, m, item, columnData );
+        }        
+        else {
+        	result = getFormatter(row, m)(row, cell, value, m, item);
+        } 
+        
+        return result;
+    }    
+    
     function getEditor(row, cell) {
       var column = columns[cell];
       var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
@@ -2353,18 +2372,7 @@ if (typeof Slick === "undefined") {
       // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
       if (item) {
         var value = getDataItemValueForColumn(item, m);
-        
-        // pass metadata to formatter
-        var metadata = data.getItemMetadata && data.getItemMetadata(row);
-        metadata = metadata && metadata.columns;
-        
-        if( metadata ) {
-        	var columnData = metadata[m.id] || metadata[cell];
-        	stringArray.push(getFormatter(row, m)(row, cell, value, m, item, columnData ));
-        }        
-        else {
-        	stringArray.push(getFormatter(row, m)(row, cell, value, m, item));
-        }
+        stringArray.push(callFormatter(row, cell, value, m, item));
       }
 
       stringArray.push("</div>");
@@ -2466,7 +2474,7 @@ if (typeof Slick === "undefined") {
       if (currentEditor && activeRow === row && activeCell === cell) {
         currentEditor.loadValue(d);
       } else {
-        cellNode.innerHTML = d ? getFormatter(row, m)(row, cell, getDataItemValueForColumn(d, m), m, d) : "";
+    	cellNode.innerHTML = d ? callFormatter(row, cell, getDataItemValueForColumn(d, m), m, d) : "";
         invalidatePostProcessingResults(row);
       }
     }
@@ -2493,7 +2501,7 @@ if (typeof Slick === "undefined") {
         if (row === activeRow && columnIdx === activeCell && currentEditor) {
           currentEditor.loadValue(d);
         } else if (d) {
-          node.innerHTML = getFormatter(row, m)(row, columnIdx, getDataItemValueForColumn(d, m), m, d);
+          node.innerHTML = callFormatter(row, columnIdx, getDataItemValueForColumn(d, m), m, d);
         } else {
           node.innerHTML = "";
         }
@@ -3814,8 +3822,7 @@ if (typeof Slick === "undefined") {
         $(activeCellNode).removeClass("editable invalid");
         if (d) {
           var column = columns[activeCell];
-          var formatter = getFormatter(activeRow, column);
-          activeCellNode[0].innerHTML = formatter(activeRow, activeCell, getDataItemValueForColumn(d, column), column, d);
+          activeCellNode[0].innerHTML = callFormatter(activeRow, activeCell, getDataItemValueForColumn(d, column), column, d);
           invalidatePostProcessingResults(activeRow);
         }
       }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -4076,7 +4076,7 @@ if (typeof Slick === "undefined") {
         return 1;
       }
 
-      var columnData = metadata.columns[columns[cell].id] || metadata.columns[cell];
+      var columnData = columns[cell] && ( metadata.columns[columns[cell].id] || metadata.columns[cell] );
       var colspan = (columnData && columnData.colspan);
       if (colspan === "*") {
         colspan = columns.length - cell;
@@ -4392,14 +4392,14 @@ if (typeof Slick === "undefined") {
       }
 
       var columnMetadata = rowMetadata && rowMetadata.columns;
-      if (columnMetadata && columnMetadata[columns[cell].id] && typeof columnMetadata[columns[cell].id].focusable === "boolean") {
+      if (columnMetadata && columns[cell] && columnMetadata[columns[cell].id] && typeof columnMetadata[columns[cell].id].focusable === "boolean") {
         return columnMetadata[columns[cell].id].focusable;
       }
       if (columnMetadata && columnMetadata[cell] && typeof columnMetadata[cell].focusable === "boolean") {
         return columnMetadata[cell].focusable;
       }
 
-      return columns[cell].focusable;
+      return columns[cell] && columns[cell].focusable;
     }
 
     function canCellBeSelected(row, cell) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2668,7 +2668,7 @@ if (typeof Slick === "undefined") {
       var numberOfRows = 0;
       var oldH = ( hasFrozenRows && !options.frozenBottom ) ? $canvasBottomL.height() : $canvasTopL.height();
 
-      if (hasFrozenRows && options.frozenBottom) {
+      if (hasFrozenRows ) {
         var numberOfRows = getDataLength() - options.frozenRow;
       } else {
         var numberOfRows = dataLengthIncludingAddNew + (options.leaveSpaceForNewRows ? numVisibleRows - 1 : 0);

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3013,7 +3013,26 @@ if (typeof Slick === "undefined") {
       cleanupRows(rendered);
 
       // add new rows & missing cells in existing rows
-      if (lastRenderedScrollLeft != scrollLeft) {    	  
+      if (lastRenderedScrollLeft != scrollLeft) {
+    	  
+    	  if ( hasFrozenRows ) {
+    		  
+    		  var renderedFrozenRows = jQuery.extend(true, {}, rendered);
+    		  
+    		  if (options.frozenBottom) {
+    			  
+    			 renderedFrozenRows.top=actualFrozenRow;
+    			 renderedFrozenRows.bottom=getDataLength();
+    		  }
+    		  else {
+             
+	             renderedFrozenRows.top=0;
+	             renderedFrozenRows.bottom=options.frozenRow;
+    		  }
+    		  
+    		  cleanUpAndRenderCells(renderedFrozenRows); 
+    	  }
+    	  
           cleanUpAndRenderCells(rendered);
       }
 

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3961,27 +3961,29 @@ if (typeof Slick === "undefined") {
     }
 
     function scrollRowIntoView(row, doPaging) {
-      if (hasFrozenRows && !options.frozenBottom) {
-        row -= actualFrozenRow;
-      }
 
-      var viewportScrollH = $viewportScrollContainerY.height();
-
-      var rowAtTop = row * options.rowHeight;
-      var rowAtBottom = (row + 1) * options.rowHeight
-        - viewportScrollH
-        + (viewportHasHScroll ? scrollbarDimensions.height : 0);
-
-      // need to page down?
-      if ((row + 1) * options.rowHeight > scrollTop + viewportScrollH + offset) {
-        scrollTo(doPaging ? rowAtTop : rowAtBottom);
-        render();
-      }
-      // or page up?
-      else if (row * options.rowHeight < scrollTop + offset) {
-        scrollTo(doPaging ? rowAtBottom : rowAtTop);
-        render();
-      }
+	    if (!hasFrozenRows ||
+	  	  ( !options.frozenBottom && row > actualFrozenRow - 1 ) ||
+	  	  ( options.frozenBottom && row < actualFrozenRow - 1 ) ) {
+    	
+	      var viewportScrollH = $viewportScrollContainerY.height();
+	
+	      var rowAtTop = row * options.rowHeight;
+	      var rowAtBottom = (row + 1) * options.rowHeight
+	        - viewportScrollH
+	        + (viewportHasHScroll ? scrollbarDimensions.height : 0);
+	
+	      // need to page down?
+	      if ((row + 1) * options.rowHeight > scrollTop + viewportScrollH + offset) {
+	        scrollTo(doPaging ? rowAtTop : rowAtBottom);
+	        render();
+	      }
+	      // or page up?
+	      else if (row * options.rowHeight < scrollTop + offset) {
+	        scrollTo(doPaging ? rowAtBottom : rowAtTop);
+	        render();
+	      }
+	    }
     }
 
     function scrollRowToTop(row) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3021,16 +3021,18 @@ if (typeof Slick === "undefined") {
       renderRows(rendered);
 
       // Render frozen rows
-      if (options.frozenBottom) {
-        renderRows({
-          top: actualFrozenRow, bottom: getDataLength() - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
-        });
+      if (hasFrozenRows) {
+	      if (options.frozenBottom) {
+	        renderRows({
+	          top: actualFrozenRow, bottom: getDataLength() - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
+	        });
+	      }
+	      else {
+	          renderRows({
+	           top: 0, bottom: options.frozenRow - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
+	          });
+	        }
       }
-      else {
-          renderRows({
-           top: 0, bottom: options.frozenRow - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
-          });
-        }      
 
       postProcessFromRow = visible.top;
       postProcessToRow = Math.min(getDataLengthIncludingAddNew() - 1, visible.bottom);

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3013,14 +3013,7 @@ if (typeof Slick === "undefined") {
       cleanupRows(rendered);
 
       // add new rows & missing cells in existing rows
-      if (lastRenderedScrollLeft != scrollLeft) {
-    	  if ( hasFrozenRows && rendered.top > options.frozenRow - 1 ) {
-              var renderedFrozenRows = jQuery.extend(true, {}, rendered);
-              renderedFrozenRows.top=0;
-              renderedFrozenRows.bottom=options.frozenRow - 1;
-              cleanUpAndRenderCells(renderedFrozenRows);    		  
-    	  }
-    	  
+      if (lastRenderedScrollLeft != scrollLeft) {    	  
           cleanUpAndRenderCells(rendered);
       }
 

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2295,7 +2295,7 @@ if (typeof Slick === "undefined") {
             appendCellHtml(stringArrayL, row, i, colspan, d);
           }
         } else if (hasFrozenColumns() && ( i <= options.frozenColumn )) {
-          appendCellHtml(stringArrayL, row, i, colspan);
+          appendCellHtml(stringArrayL, row, i, colspan, d);
         }
 
         if (colspan > 1) {
@@ -3014,18 +3014,30 @@ if (typeof Slick === "undefined") {
 
       // add new rows & missing cells in existing rows
       if (lastRenderedScrollLeft != scrollLeft) {
-        cleanUpAndRenderCells(rendered);
+    	  if ( hasFrozenRows && rendered.top > options.frozenRow - 1 ) {
+              var renderedFrozenRows = jQuery.extend(true, {}, rendered);
+              renderedFrozenRows.top=0;
+              renderedFrozenRows.bottom=options.frozenRow - 1;
+              cleanUpAndRenderCells(renderedFrozenRows);    		  
+    	  }
+    	  
+          cleanUpAndRenderCells(rendered);
       }
 
       // render missing rows
       renderRows(rendered);
 
-      // Render frozen bottom rows
+      // Render frozen rows
       if (options.frozenBottom) {
         renderRows({
           top: actualFrozenRow, bottom: getDataLength() - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
         });
       }
+      else {
+          renderRows({
+           top: 0, bottom: options.frozenRow - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
+          });
+        }      
 
       postProcessFromRow = visible.top;
       postProcessToRow = Math.min(getDataLengthIncludingAddNew() - 1, visible.bottom);


### PR DESCRIPTION
Fix some bugs / add enhancement
- Fix frozen columns bug.

You can see this bug in this demo : http://jsfiddle.net/Francks11/0kj44tbn/1/
1. Scroll the grid to the right
2. Scroll down

![1](https://cloud.githubusercontent.com/assets/3995851/8351836/721e52ea-1b30-11e5-964f-d08101a35b09.png)

Fix with this change : https://github.com/Francks11/X-SlickGrid/commit/a96f15ce9343e81300a5cdd4c11bce531a6f110e#diff-7f1ab5db3c0316e19a9ee635a1e2f2d0R2298

appendCellHtml(stringArrayL, row, i, colspan, d);
- Fix frozen rows bug : 

You can see this bug in this demo : http://jsfiddle.net/Francks11/0kj44tbn/2/
1. Scroll down
2. Scroll right

![2](https://cloud.githubusercontent.com/assets/3995851/8354252/effff46e-1b46-11e5-92eb-f4bd05afb117.png)

Fix with this change :  https://github.com/Francks11/X-SlickGrid/commit/44a9796ac360a146bc2aa6e69da8d986070426d7 https://github.com/Francks11/X-SlickGrid/commit/3182e4eedb1d6f72b7ba8f26411dcb22bf5329cf
- When we edit cell in frozen row on top or bottom, the scrollbar go to top or bottom :

You can see this bug in this demo : http://jsfiddle.net/Francks11/0kj44tbn/3/

1) Scroll dow
2) Click to cell Duration.

You can see that the scrollbar go to top.

Fix with change : https://github.com/Francks11/X-SlickGrid/commit/d5417103e649d279007b9049bab5a2df636de3c1
- Fix space on end of table when frozen rows are used.

You can see a demo here : http://jsfiddle.net/Francks11/0kj44tbn/3/

1) Scroll down.

And see : 

![3](https://cloud.githubusercontent.com/assets/3995851/8354218/a7bf5ece-1b46-11e5-9197-d295fa80c092.png)

Fix with changes : https://github.com/Francks11/X-SlickGrid/commit/70f776e4e7f6db14a6cbb5485bc3a3082f9637ac
- Fix javascript error appears when we have have colspan on frozen row and when we edit cell.
  Can not produce a demo because I can't reproduce it with this example.

Fix with change : https://github.com/Francks11/X-SlickGrid/commit/7a2fe0a2808fe9b6c39c74af3b96841ddd216cc4
- Add enhancement for columns reordering. Give the possibility to retrieve impacted columns from method onColumnsReordered. Useful in the case where the columns are grouped. Suppose there are 3 groups. If group 2 changes, columns of group 2 can be retrieve in onColumnsReordered event method.

Concerned changes : https://github.com/Francks11/X-SlickGrid/commit/dc5af17b8d9b27896345422fb6f77ef94d2ea785
- Add enhancement for formatter. Add new parameter metadata, which can be use from formatter method. 

Pass parameters in metadata : 

```
columns: { 
    "COLUMN NAME" : { editor : Slick.Editors.Decimal, formatter : Slick.Formatters.EditableDouble, pattern : "PATTERN", locale : "LOCALE" },                        
}
```

And use it on formatter method : 

```
    function DoubleFormatter(row, cell, value, columnDef, dataContext, metadata ) {

        var formattedValue = value.toString().replace( ",", "." );

        if( metadata && metadata.pattern ) {
            formattedValue = jQuery.formatNumber( formattedValue, { format: metadata.pattern, locale: metadata.locale } );
        }

        return formattedValue;
    }

```

Concerned changes : https://github.com/Francks11/X-SlickGrid/commit/b2e14e6cb169de6059757434e7db458a997320b3 https://github.com/Francks11/X-SlickGrid/commit/ec1374ebf569435c828100c2715f31caa48ed62e
