### PR TITLE
Disable scrolling of right viewport when dragging columns in the left viewport

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1217,6 +1217,7 @@ if (typeof Slick === "undefined") {
         $viewportScrollContainerX[0].scrollLeft = $viewportScrollContainerX[0].scrollLeft - 10;
       }
 
+	  var canDragScroll;
       $headers.sortable({
         containment: "parent",
         distance: 3,
@@ -1227,18 +1228,20 @@ if (typeof Slick === "undefined") {
         placeholder: "slick-sortable-placeholder ui-state-default slick-header-column",
         start: function (e, ui) {
           ui.placeholder.width(ui.helper.outerWidth() - headerColumnWidthDiff);
-          $(ui.helper).addClass("slick-header-column-active");
+          canDragScroll = !hasFrozenColumns() ||
+            (ui.placeholder.offset().left + ui.placeholder.width()) > $viewportScrollContainerX.offset().left;
+	      $(ui.helper).addClass("slick-header-column-active");
         },
         beforeStop: function (e, ui) {
           $(ui.helper).removeClass("slick-header-column-active");
         },
         sort: function (e, ui) {
-          if (e.originalEvent.pageX > $container[0].clientWidth) {
+          if (canDragScroll && e.originalEvent.pageX > $container[0].clientWidth) {
             if (!(columnScrollTimer)) {
               columnScrollTimer = setInterval(
                 scrollColumnsRight, 100);
             }
-          } else if (e.originalEvent.pageX < $viewportScrollContainerX.offset().left) {
+          } else if (canDragScroll && e.originalEvent.pageX < $viewportScrollContainerX.offset().left) {
             if (!(columnScrollTimer)) {
               columnScrollTimer = setInterval(
                 scrollColumnsLeft, 100);


### PR DESCRIPTION
This will disable scrolling when dragging a frozen column, since there is no scroll for that viewport. You can see the bug here: http://jlynch7.github.io/SlickGrid/examples/example-frozen-columns.html
1. Scroll to the right
2. Drag a column on the left side. You will then see that the right viewport scrolls to the left.
