### PR TITLE
Disable mousewheel events from scrolling the window

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3071,14 +3071,14 @@ if (typeof Slick === "undefined") {
 
       scrollTop = Math.max(0, $viewportScrollContainerY[0].scrollTop - (deltaY * options.rowHeight));
       scrollLeft = $viewportScrollContainerX[0].scrollLeft + (deltaX * 10);
-      _handleScroll(true);
-      e.preventDefault();
+      var handled = _handleScroll(true);
+      if (handled) e.preventDefault();
     }
 
     function handleScroll() {
       scrollTop = $viewportScrollContainerY[0].scrollTop;
       scrollLeft = $viewportScrollContainerX[0].scrollLeft;
-      _handleScroll(false);
+      return _handleScroll(false);
     }
 
     function _handleScroll(isMouseWheel) {
@@ -3169,6 +3169,9 @@ if (typeof Slick === "undefined") {
       }
 
       trigger(self.onScroll, {scrollLeft: scrollLeft, scrollTop: scrollTop});
+	  
+      if (hScrollDist || vScrollDist) return true;
+      return false;
     }
 
     function asyncPostProcessRows() {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3072,6 +3072,7 @@ if (typeof Slick === "undefined") {
       scrollTop = Math.max(0, $viewportScrollContainerY[0].scrollTop - (deltaY * options.rowHeight));
       scrollLeft = $viewportScrollContainerX[0].scrollLeft + (deltaX * 10);
       _handleScroll(true);
+      e.preventDefault();
     }
 
     function handleScroll() {


### PR DESCRIPTION
When scrolling the right viewport, it'll just scroll as expected. But when mousewheel-scrolling the left viewport, it'll scroll the viewport as well as scrolling the window behind it.

In the demo at jlynch site this appears to work as expected already, the "e.preventDefault();" line exists in that version. I can't see if it'd cause any problems that had it removed but scrolling behaves in strange ways without it.

To see the bug:
1. Open example-frozen-columns.html
2. Make the browser height smaller than the grid height
3. Hold the mouse over the frozen columns and scroll down, this will scroll the grid as expected but then pass the scroll-event to the window and scroll that as well.

Alternatively maybe the solution could be
"if (scrollTop) e.preventDefault();" to have it pass along scroll-events to the window if it's already scrolled to the end, but I committed the way it worked previously in jlynch example.
